### PR TITLE
extend classname combinations from 1026 to 3392

### DIFF
--- a/lib/classGenerator.js
+++ b/lib/classGenerator.js
@@ -1,7 +1,7 @@
 const chalk = require('./chalk');
 
-const acceptPrefix = 'abcdefghijklmnopqrstuvwxyz_'.split('');
-const acceptChars = 'abcdefghijklmnopqrstuvwxyz_-0123456789'.split('');
+const acceptPrefix = 'aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ_'.split('');
+const acceptChars = 'aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ_-0123456789'.split('');
 
 function ClassGenerator() {
     this.newClassMap = {};


### PR DESCRIPTION
Extend the number of maximal classnames with 2 characters from 27x38=1026 to 53x64=3392