### PR TITLE
Allow back ticks as prefix to classNameRegExp in html and js files

### DIFF
--- a/lib/optimizer.js
+++ b/lib/optimizer.js
@@ -21,7 +21,7 @@ const optimize = (compiler, [file, originalSource], compilation, opts, classGene
   if (file.match(/.+\.css.*$/)) {
     classnameRegex = new RegExp(`\\\.(${opts.classNameRegExp})`, 'g');
   } else if (file.match(/.+\.js.*$/) || file.match(/.+\.html.*$/)) {
-    classnameRegex = new RegExp(`["'.\\\s](${opts.classNameRegExp})`, 'g');
+    classnameRegex = new RegExp(`["'\`.\\\s](${opts.classNameRegExp})`, 'g');
   }
   if (!classnameRegex) {
     return;


### PR DESCRIPTION
Fixes #43 